### PR TITLE
[feature] 모집을 추가해서 저장하는 테이블을 구현한다.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -14,11 +14,16 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// lombok 설치
+	compileOnly 'org.projectlombok:lombok'
+
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/backend/src/main/java/com/apply/BackendApplication.java
+++ b/backend/src/main/java/com/apply/BackendApplication.java
@@ -8,6 +8,7 @@ public class BackendApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(BackendApplication.class, args);
+		// Hello world
 	}
 
 }

--- a/backend/src/main/java/com/apply/admin/recruitment/controller/RecruitmentController.java
+++ b/backend/src/main/java/com/apply/admin/recruitment/controller/RecruitmentController.java
@@ -1,0 +1,29 @@
+package com.apply.admin.recruitment.controller;
+
+import com.apply.admin.recruitment.dto.request.NewRecruitmentRequest;
+import com.apply.admin.recruitment.dto.response.NewRecruitmentResponse;
+import com.apply.admin.recruitment.dto.response.RecruitmentResponse;
+import com.apply.admin.recruitment.service.RecruitmentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.net.URI;
+
+@RequestMapping("/api/recruitments")
+@RestController
+public class RecruitmentController {
+
+    private final RecruitmentService recruitmentService;
+
+    public RecruitmentController(final RecruitmentService recruitmentService) {
+        this.recruitmentService = recruitmentService;
+    }
+
+    @PostMapping
+    public ResponseEntity<RecruitmentResponse> createRecruitment(@Valid @RequestBody NewRecruitmentRequest newRecruitmentRequest) {
+        NewRecruitmentResponse recruitment = recruitmentService.createBoard(newRecruitmentRequest);
+        return ResponseEntity.created(URI.create("/recruitments/" + recruitment.getIdx())).build();
+    }
+
+}

--- a/backend/src/main/java/com/apply/admin/recruitment/domain/Recruitment.java
+++ b/backend/src/main/java/com/apply/admin/recruitment/domain/Recruitment.java
@@ -15,7 +15,7 @@ public class Recruitment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "idx")
-    private int idx;
+    private Long idx;
 
     @Column(name = "course", nullable = false, length = 10)
     private String course;
@@ -30,8 +30,8 @@ public class Recruitment extends BaseEntity {
     @Column(name = "recruitment_status", nullable = false)
     private RecruitmentStatus recruitmentStatus;
 
-    @Column(name = "profile_image_url", nullable = false)
-    private String profileImageUrl;
+    @Column(name = "curriculumImage", nullable = false, length = 100)
+    private String curriculumImage;
 
     @CreatedDate
     @Column(name = "start_date", nullable = false)
@@ -45,14 +45,50 @@ public class Recruitment extends BaseEntity {
     }
 
     @Builder
-    public Recruitment(int idx, String course, int contentMaxSize, int headCount, RecruitmentStatus recruitmentStatus, String profileImageUrl, LocalDateTime startDate, LocalDateTime dueDate, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+    public Recruitment(Long idx, String course, int contentMaxSize, int headCount, RecruitmentStatus recruitmentStatus, String curriculumImage, LocalDateTime startDate, LocalDateTime dueDate) {
         this.idx = idx;
         this.course = course;
         this.contentMaxSize = contentMaxSize;
         this.headCount = headCount;
         this.recruitmentStatus = recruitmentStatus;
-        this.profileImageUrl = profileImageUrl;
+        this.curriculumImage = curriculumImage;
         this.startDate = startDate;
         this.dueDate = dueDate;
+    }
+
+    public void change(final String course) {
+        this.course = course;
+    }
+
+    public Long getIdx() {
+        return idx;
+    }
+
+    public String getCourse() {
+        return course;
+    }
+
+    public int getContentMaxSize() {
+        return contentMaxSize;
+    }
+
+    public int getHeadCount() {
+        return headCount;
+    }
+
+    public RecruitmentStatus getRecruitmentStatus() {
+        return recruitmentStatus;
+    }
+
+    public String getCurriculumImage() {
+        return curriculumImage;
+    }
+
+    public LocalDateTime getStartDate() {
+        return startDate;
+    }
+
+    public LocalDateTime getDueDate() {
+        return dueDate;
     }
 }

--- a/backend/src/main/java/com/apply/admin/recruitment/domain/Recruitment.java
+++ b/backend/src/main/java/com/apply/admin/recruitment/domain/Recruitment.java
@@ -1,0 +1,58 @@
+package com.apply.admin.recruitment.domain;
+
+import com.apply.common.BaseEntity;
+import lombok.Builder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Table(name = "recruitments")
+@Entity
+public class Recruitment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "idx")
+    private int idx;
+
+    @Column(name = "course", nullable = false, length = 10)
+    private String course;
+
+    @Column(name = "content_max_size", nullable = false)
+    private int contentMaxSize;
+
+    @Column(name = "head_count", nullable = false)
+    private int headCount;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "recruitment_status", nullable = false)
+    private RecruitmentStatus recruitmentStatus;
+
+    @Column(name = "profile_image_url", nullable = false)
+    private String profileImageUrl;
+
+    @CreatedDate
+    @Column(name = "start_date", nullable = false)
+    private LocalDateTime startDate;
+
+    @LastModifiedDate
+    @Column(name = "due_date", nullable = false)
+    private LocalDateTime dueDate;
+
+    public Recruitment() {
+    }
+
+    @Builder
+    public Recruitment(int idx, String course, int contentMaxSize, int headCount, RecruitmentStatus recruitmentStatus, String profileImageUrl, LocalDateTime startDate, LocalDateTime dueDate, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        this.idx = idx;
+        this.course = course;
+        this.contentMaxSize = contentMaxSize;
+        this.headCount = headCount;
+        this.recruitmentStatus = recruitmentStatus;
+        this.profileImageUrl = profileImageUrl;
+        this.startDate = startDate;
+        this.dueDate = dueDate;
+    }
+}

--- a/backend/src/main/java/com/apply/admin/recruitment/domain/RecruitmentStatus.java
+++ b/backend/src/main/java/com/apply/admin/recruitment/domain/RecruitmentStatus.java
@@ -1,0 +1,8 @@
+package com.apply.admin.recruitment.domain;
+
+public enum RecruitmentStatus {
+
+    HOLDING,
+    PROCEEDING,
+    COMPLETED
+}

--- a/backend/src/main/java/com/apply/admin/recruitment/dto/request/NewRecruitmentRequest.java
+++ b/backend/src/main/java/com/apply/admin/recruitment/dto/request/NewRecruitmentRequest.java
@@ -1,0 +1,19 @@
+package com.apply.admin.recruitment.dto.request;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class NewRecruitmentRequest {
+
+    @NotBlank
+    private String course;
+
+    public NewRecruitmentRequest() {
+    }
+
+    public NewRecruitmentRequest(String course) {
+        this.course = course;
+    }
+}

--- a/backend/src/main/java/com/apply/admin/recruitment/dto/request/RecruitmentUpdateRequest.java
+++ b/backend/src/main/java/com/apply/admin/recruitment/dto/request/RecruitmentUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.apply.admin.recruitment.dto.request;
+
+import javax.validation.constraints.NotBlank;
+
+public class RecruitmentUpdateRequest {
+
+    @NotBlank(message = "모집명이 공백일 수 없습니다")
+    private String course;
+
+    private RecruitmentUpdateRequest() {
+    }
+
+    public RecruitmentUpdateRequest(final String course) {
+        this.course = course;
+    }
+
+    public String getCourse() {
+        return course;
+    }
+}

--- a/backend/src/main/java/com/apply/admin/recruitment/dto/response/NewRecruitmentResponse.java
+++ b/backend/src/main/java/com/apply/admin/recruitment/dto/response/NewRecruitmentResponse.java
@@ -1,0 +1,20 @@
+package com.apply.admin.recruitment.dto.response;
+
+import com.apply.admin.recruitment.domain.Recruitment;
+
+public class NewRecruitmentResponse {
+
+    private Long idx;
+
+    public NewRecruitmentResponse(Long idx) {
+        this.idx = idx;
+    }
+
+    public NewRecruitmentResponse(Recruitment recruitment) {
+        this.idx = recruitment.getIdx();
+    }
+
+    public Long getIdx() {
+        return idx;
+    }
+}

--- a/backend/src/main/java/com/apply/admin/recruitment/dto/response/RecruitmentResponse.java
+++ b/backend/src/main/java/com/apply/admin/recruitment/dto/response/RecruitmentResponse.java
@@ -1,0 +1,49 @@
+package com.apply.admin.recruitment.dto.response;
+
+import com.apply.admin.recruitment.domain.Recruitment;
+import com.apply.admin.recruitment.domain.RecruitmentStatus;
+
+import java.time.LocalDateTime;
+
+public class RecruitmentResponse {
+
+    private Long idx;
+
+    private String course;
+
+    private int contentMaxSize;
+
+    private int headCount;
+
+    private RecruitmentStatus recruitmentStatus;
+
+    private String curriculumImage;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime dueDate;
+
+    private RecruitmentResponse() {
+    }
+
+    public RecruitmentResponse(final Long idx, final String course, final int contentMaxSize,
+                               final int headCount, final RecruitmentStatus recruitmentStatus, final String curriculumImage,
+                               final LocalDateTime startDate, final LocalDateTime dueDate) {
+        this.idx = idx;
+        this.course = course;
+        this.contentMaxSize = contentMaxSize;
+        this.headCount = headCount;
+        this.recruitmentStatus = recruitmentStatus;
+        this.curriculumImage = curriculumImage;
+        this.startDate = startDate;
+        this.dueDate = dueDate;
+    }
+
+    public RecruitmentResponse(final Recruitment recruitment) {
+        this(recruitment.getIdx(), recruitment.getCourse(), recruitment.getContentMaxSize(),
+                recruitment.getHeadCount(), recruitment.getRecruitmentStatus(), recruitment.getCurriculumImage(),
+                recruitment.getStartDate(), recruitment.getDueDate());
+    }
+
+
+}

--- a/backend/src/main/java/com/apply/admin/recruitment/exception/NoSuchRecruitmentException.java
+++ b/backend/src/main/java/com/apply/admin/recruitment/exception/NoSuchRecruitmentException.java
@@ -1,0 +1,11 @@
+package com.apply.admin.recruitment.exception;
+
+public class NoSuchRecruitmentException extends RuntimeException {
+    public NoSuchRecruitmentException(final String message) {
+        super(message);
+    }
+
+    public NoSuchRecruitmentException() {
+        this("존재하지 않는 모집글입니다.");
+    }
+}

--- a/backend/src/main/java/com/apply/admin/recruitment/repository/RecruitmentRepository.java
+++ b/backend/src/main/java/com/apply/admin/recruitment/repository/RecruitmentRepository.java
@@ -1,0 +1,27 @@
+package com.apply.admin.recruitment.repository;
+
+import com.apply.admin.recruitment.domain.Recruitment;
+import com.apply.admin.recruitment.exception.NoSuchRecruitmentException;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
+
+    Optional<Recruitment> findByCourse(final String course);
+
+    default Recruitment getById(final Long idx) {
+        return findById(idx)
+                .orElseThrow(NoSuchRecruitmentException::new);
+    }
+
+    default Recruitment getByCourse(final String course) {
+        return findByCourse(course)
+                .orElseThrow(NoSuchRecruitmentException::new);
+    }
+
+    @Query(value = "SELECT r.course FROM Recruitment r WHERE r.idx = : idx")
+    Optional<Integer> findByCourseValueById(@Param("idx") int idx);
+}

--- a/backend/src/main/java/com/apply/admin/recruitment/service/RecruitmentService.java
+++ b/backend/src/main/java/com/apply/admin/recruitment/service/RecruitmentService.java
@@ -1,0 +1,42 @@
+package com.apply.admin.recruitment.service;
+
+import com.apply.admin.recruitment.domain.Recruitment;
+import com.apply.admin.recruitment.dto.request.NewRecruitmentRequest;
+import com.apply.admin.recruitment.dto.request.RecruitmentUpdateRequest;
+import com.apply.admin.recruitment.dto.response.NewRecruitmentResponse;
+import com.apply.admin.recruitment.dto.response.RecruitmentResponse;
+import com.apply.admin.recruitment.repository.RecruitmentRepository;
+import org.springframework.stereotype.Service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+public class RecruitmentService {
+
+    private final RecruitmentRepository recruitmentRepository;
+
+    public RecruitmentService(RecruitmentRepository recruitmentRepository) {
+        this.recruitmentRepository = recruitmentRepository;
+    }
+
+    // 모집글 생성시
+    @Transactional
+    public NewRecruitmentResponse createBoard(NewRecruitmentRequest newRecruitmentRequest) {
+        Recruitment recruitment = Recruitment.builder()
+                .course(newRecruitmentRequest.getCourse())
+                .build();
+
+        Recruitment saverecruitment = recruitmentRepository.save(recruitment);
+        return new NewRecruitmentResponse(saverecruitment);
+    }
+
+
+    // 모집글 수정시
+    @Transactional
+    public void update(final Long idx, final RecruitmentUpdateRequest request) {
+        Recruitment recruitment = recruitmentRepository.getById(idx);
+        recruitment.change(request.getCourse());
+    }
+
+}

--- a/backend/src/main/java/com/apply/common/BaseEntity.java
+++ b/backend/src/main/java/com/apply/common/BaseEntity.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseEntity {
+public abstract class BaseEntity {
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/backend/src/main/java/com/apply/common/BaseEntity.java
+++ b/backend/src/main/java/com/apply/common/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.apply.common;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}


### PR DESCRIPTION
## 구현 기능

* 모집을 추가해서 저장하는 테이블을 구현한다.

## 세부 작업 내용

 - [x] 모집 테이블 안에 넣을 항목(`반정보`, `모집항목수`, `시작일`, `마감일`, `인원수`, `커리큘럼 이미지`, `모집상태`, `등록일자`, `수정일자`)를 저장한다.
 - [x] DTO는 dto 패키지 폴더안에 request, response 패키지 폴더로 구분하여 각각의 클래스로 만들어서 구현한다.
 - [x] 모집 관리 테이블 뿐만 아니라, 다른 테이블에도 공통적으로 적용할 필드가 있으면, `common` 패키지 폴더안에 `BaseEntity` 이름으로 **추상 클래스**를 선언한다.
 - [x] 모집 테이블에 대한 `예외 처리`를 구현한다. 

### 관련 이슈

* Close #18 

## To Reviewer

* (리뷰어에게 하고 싶은 말)
